### PR TITLE
pacupg: Fix AUR packages not being installed after build

### DIFF
--- a/pacupg/pacupg
+++ b/pacupg/pacupg
@@ -84,7 +84,7 @@ aur(){
         sudo sed -i '/clean=/d' $pacaurconfig && 
         echo "clean=true" | sudo tee -a $pacaurconfig > /dev/null # Make sure clean option is off in pacaur
 
-    builddir=${builddir:-/tmp/pacaurtmp-$USER}
+    builddir=${builddir:-${TMPDIR:-/tmp}/pacaurtmp-$USER}
 
 
     msg "Checking for updates...\n"

--- a/pacupg/pacupg
+++ b/pacupg/pacupg
@@ -95,8 +95,13 @@ aur(){
         return 2
     fi
     rm -rf "$builddir" && mkdir "$builddir"
+
+    # Make sure the packages land in the folder we expect by setting PKGDEST before building the packages.
+    # PKGDEST is used by makepkg as a target location for built packages (see man makepkg.conf).
+    export PKGDEST="${builddir}"
     if eval "pacaur --color always -Syuw $devel"; then
     buildpkgs=$(find $builddir -type f -regex ".*\.pkg\.\(tar\|tar\.[gx]z\)")
+
     if [[ -n $buildpkgs ]]; then
             eval "in_block=1"
             # Take snapshot and store snapshot number in $pre

--- a/pacupg/pacupg
+++ b/pacupg/pacupg
@@ -80,14 +80,14 @@ aur(){
         exit 1
     fi
     source "${pacaurconfig}"
-    [[ -z "${clean}" || "${clean}" != "true" ]] &&
-        sudo sed -i '/clean=/d' "${pacaurconfig}" &&
-        echo "clean=true" | sudo tee -a "${pacaurconfig}" > /dev/null # Make sure clean option is off in pacaur
+    [[ -z ${clean} || ${clean} != true ]] &&
+        sudo sed -i '/clean=/d' "$pacaurconfig" &&
+        echo "clean=true" | sudo tee -a "$pacaurconfig" > /dev/null # Make sure clean option is off in pacaur
 
     builddir="${builddir:-${TMPDIR:-/tmp}/pacaurtmp-$USER}"
 
     msg "Checking for updates...\n"
-    aurpkgs="$(pacaur --color never ${ignoreopts} ${devel} --check | awk -F'aur  ' '{print $2}')"
+    aurpkgs="$(pacaur --color never $ignoreopts $devel --check | awk -F'aur  ' '{print $2}')"
     if [[ -z "${aurpkgs}" ]]; then
         msg "No AUR packages to upgrade.\n"
         [[ "${pkgsupgraded}" == 1 ]] && { btrgrub;  msg "Log of upgraded packages available at ${log_file}\n"; return; }
@@ -103,7 +103,7 @@ aur(){
     if [[ "${buildpkgs}" ]]; then
             eval "in_block=1"
             # Take snapshot and store snapshot number in $pre
-            pre="$(sudo snapper create --type=pre --cleanup-algorithm=number --print-number --description="AUR upgrade")"
+            pre=$(sudo snapper create --type=pre --cleanup-algorithm=number --print-number --description="AUR upgrade")
             msg "New pre snapshot with number ${pre}\n"
             sudo pacman -U --noconfirm ${ignoreopts} ${buildpkgs} && msg "Packages upgraded\n" || return 1
             msg "Taking post snapshot\n"
@@ -113,7 +113,7 @@ aur(){
                 rm "${pkg}"
             done
             msg "Snapshot block complete: $snpr_cnfg/${pre}..${post}\n"
-            echo -e "\nAUR packages upgraded: \n\n$aurpkgs" | sudo tee -a "${log_file}" > /dev/null
+            echo -e "\nAUR packages upgraded: \n\n$aurpkgs" | sudo tee -a "$log_file" > /dev/null
             eval "in_block=0"
             btrgrub
             msg "Log of upgraded packages available at ${log_file}\n\n"

--- a/pacupg/pacupg
+++ b/pacupg/pacupg
@@ -79,43 +79,41 @@ aur(){
         warn "pacaur not found. Aborting\n"
         exit 1
     fi
-    source $pacaurconfig
-    [[ -z $clean || $clean != "true" ]] &&  
-        sudo sed -i '/clean=/d' $pacaurconfig && 
-        echo "clean=true" | sudo tee -a $pacaurconfig > /dev/null # Make sure clean option is off in pacaur
+    source "${pacaurconfig}"
+    [[ -z "${clean}" || "${clean}" != "true" ]] &&
+        sudo sed -i '/clean=/d' "${pacaurconfig}" &&
+        echo "clean=true" | sudo tee -a "${pacaurconfig}" > /dev/null # Make sure clean option is off in pacaur
 
-    builddir=${builddir:-${TMPDIR:-/tmp}/pacaurtmp-$USER}
-
+    builddir="${builddir:-${TMPDIR:-/tmp}/pacaurtmp-$USER}"
 
     msg "Checking for updates...\n"
-    aurpkgs=$(pacaur --color never $ignoreopts $devel --check | awk -F'aur  ' '{print $2}')
-    if [[ -z $aurpkgs ]]; then
+    aurpkgs="$(pacaur --color never ${ignoreopts} ${devel} --check | awk -F'aur  ' '{print $2}')"
+    if [[ -z "${aurpkgs}" ]]; then
         msg "No AUR packages to upgrade.\n"
-        [[ $pkgsupgraded == 1 ]] && { btrgrub;  msg "Log of upgraded packages available at ${log_file}\n"; return; }
+        [[ "${pkgsupgraded}" == 1 ]] && { btrgrub;  msg "Log of upgraded packages available at ${log_file}\n"; return; }
         return 2
     fi
-    rm -rf "$builddir" && mkdir "$builddir"
+    rm -rf "${builddir}" && mkdir "${builddir}"
 
     # Make sure the packages land in the folder we expect by setting PKGDEST before building the packages.
     # PKGDEST is used by makepkg as a target location for built packages (see man makepkg.conf).
     export PKGDEST="${builddir}"
     if eval "pacaur --color always -Syuw $devel"; then
-    buildpkgs=$(find $builddir -type f -regex ".*\.pkg\.\(tar\|tar\.[gx]z\)")
-
-    if [[ -n $buildpkgs ]]; then
+    buildpkgs="$(find ${builddir} -type f -regex ".*\.pkg\.\(tar\|tar\.[gx]z\)")"
+    if [[ "${buildpkgs}" ]]; then
             eval "in_block=1"
             # Take snapshot and store snapshot number in $pre
-            pre=$(sudo snapper create --type=pre --cleanup-algorithm=number --print-number --description="AUR upgrade") 
+            pre="$(sudo snapper create --type=pre --cleanup-algorithm=number --print-number --description="AUR upgrade")"
             msg "New pre snapshot with number ${pre}\n"
-            sudo pacman -U --noconfirm $ignoreopts $buildpkgs && msg "Packages upgraded\n" || return 1
+            sudo pacman -U --noconfirm ${ignoreopts} "${buildpkgs}" && msg "Packages upgraded\n" || return 1
             msg "Taking post snapshot\n"
             # Take post snapshot and store number in $post
-            post=$(sudo snapper create --type=post --cleanup-algorithm=number --print-number --pre-number="$pre") 
-            for pkg in "$buildpkgs"; do 
-                rm $pkg
+            post="$(sudo snapper create --type=post --cleanup-algorithm=number --print-number --pre-number="$pre")"
+            for pkg in "${buildpkgs}"; do
+                rm "${pkg}"
             done
             msg "Snapshot block complete: $snpr_cnfg/${pre}..${post}\n"
-            echo -e "\nAUR packages upgraded: \n\n$aurpkgs" | sudo tee -a $log_file > /dev/null
+            echo -e "\nAUR packages upgraded: \n\n$aurpkgs" | sudo tee -a "${log_file}" > /dev/null
             eval "in_block=0"
             btrgrub
             msg "Log of upgraded packages available at ${log_file}\n\n"

--- a/pacupg/pacupg
+++ b/pacupg/pacupg
@@ -98,7 +98,7 @@ aur(){
     # Make sure the packages land in the folder we expect by setting PKGDEST before building the packages.
     # PKGDEST is used by makepkg as a target location for built packages (see man makepkg.conf).
     export PKGDEST="${builddir}"
-    if eval "pacaur --color always -Syuw $devel"; then
+    if eval "pacaur --color always -Syuw ${devel}"; then
     buildpkgs="$(find ${builddir} -type f -regex ".*\.pkg\.\(tar\|tar\.[gx]z\)")"
     if [[ "${buildpkgs}" ]]; then
             eval "in_block=1"
@@ -109,7 +109,7 @@ aur(){
             msg "Taking post snapshot\n"
             # Take post snapshot and store number in $post
             post="$(sudo snapper create --type=post --cleanup-algorithm=number --print-number --pre-number="$pre")"
-            for pkg in "${buildpkgs}"; do
+            for pkg in ${buildpkgs}; do
                 rm "${pkg}"
             done
             msg "Snapshot block complete: $snpr_cnfg/${pre}..${post}\n"

--- a/pacupg/pacupg
+++ b/pacupg/pacupg
@@ -105,7 +105,7 @@ aur(){
             # Take snapshot and store snapshot number in $pre
             pre="$(sudo snapper create --type=pre --cleanup-algorithm=number --print-number --description="AUR upgrade")"
             msg "New pre snapshot with number ${pre}\n"
-            sudo pacman -U --noconfirm ${ignoreopts} "${buildpkgs}" && msg "Packages upgraded\n" || return 1
+            sudo pacman -U --noconfirm ${ignoreopts} ${buildpkgs} && msg "Packages upgraded\n" || return 1
             msg "Taking post snapshot\n"
             # Take post snapshot and store number in $post
             post="$(sudo snapper create --type=post --cleanup-algorithm=number --print-number --pre-number="$pre")"


### PR DESCRIPTION
On my system AUR packages are built in $AURDEST (used by pacaur) which defaults to ~/.cache/pacaur. Since pacupg looks for built AUR packages in /tmp/pacaurtmp-$USER it did not find the artefacts and never installed AUR upgrades after building them. This PR fixes that. It also tries to use $TMPDIR now before resorting to /tmp. Lastly, some minor refactoring/quoting for safer variable usage.
